### PR TITLE
Addition of Punjabi (pa) corpus data

### DIFF
--- a/language-data.json
+++ b/language-data.json
@@ -201,6 +201,12 @@
 		"infopage": "https://wortschatz.uni-leipzig.de/en/download/Luxembourgish",
 		"source": "unileipzig"
 	},
+	"pa": {
+		"qid": "Q58635",
+		"remotefile": "pa_20230125/pa.txt.gz",
+		"infopage": "https://cqpweb.lancs.ac.uk/emillepunsp/index.php?ui=corpusMetadata",
+		"source": "archiveorg"
+	},
 	"ml": {
 		"qid": "Q36236",
 		"remotefile": "mal_wikipedia_2016_300K.tar.gz",

--- a/meta.py
+++ b/meta.py
@@ -42,6 +42,11 @@ for language in data:
 			"https://pcai056.informatik.uni-leipzig.de/downloads/corpora/" \
 			+ data[language]["remotefile"]
 
+	elif source == "archiveorg":
+		data[language]["remoteurl"] = \
+			"https://archive.org/download/" \
+			+ data[language]["remotefile"]
+
 	else:
 		print("ERROR: Unrecognised source for " + language + ": " + source)
 


### PR DESCRIPTION
Hopefully I did this right, I have added an entry to the language data JSON table, and a condition for archive.org for the source. I uploaded a custom version of a speech corpus with some minor tidying applied in the interest of avoiding biases introduced in an internet-based corpus and by differences in the two writing systems. The file is just a big gzipped txt of the tokens separated by line breaks.