### PR TITLE
feat(language-data.json): Support Odia (or) lang

### DIFF
--- a/language-data.json
+++ b/language-data.json
@@ -225,6 +225,12 @@
 		"infopage": "https://wortschatz.uni-leipzig.de/en/download/Norwegian%20Nynorsk",
 		"source": "unileipzig"
 	},
+	"or": {
+		"qid": "Q33810",
+		"remotefile": "ori_wikipedia_2021_100K.tar.gz",
+		"infopage": "https://wortschatz.uni-leipzig.de/en/download/Oriya",
+		"source": "unileipzig"
+	},
 	"se": {
 		"qid": "Q33947",
 		"remotefile": "sme-no_web_2013_10K.tar.gz",


### PR DESCRIPTION
- This can be used to generate [stats](https://www.wikidata.org/wiki/Wikidata:Lexicographical_coverage) for [Odia language](https://en.wikipedia.org/wiki/Odia_language).